### PR TITLE
Support for multiple nodes

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -13,7 +13,6 @@ class McuCamera extends Node {
 	//console.log("imagetype,width,height:"+imagetype+","+width+","+height);
 
 	const cacheCamera = 'mcu_camera';
-	console.log(cacheCamera);
 
 	cache ??= new Map;
 	camera = cache.get(cacheCamera);

--- a/camera.js
+++ b/camera.js
@@ -2,6 +2,7 @@ import {Node} from "nodered";
 import Camera from "embedded:x-io/imagein/camera";
 import Timer from "timer";
 let camera, frame, imagetype, width, height;
+let cache;
 
 class McuCamera extends Node {
     onStart(config) {
@@ -11,14 +12,22 @@ class McuCamera extends Node {
         height = Number(config.height);
 	//console.log("imagetype,width,height:"+imagetype+","+width+","+height);
 
-	camera = new Camera({
-		width,
-		height,
-		imageType: imagetype,
-		format: "buffer/disposable",
-	});
-	camera.start();
-    };
+	const cacheCamera = 'mcu_camera';
+	console.log(cacheCamera);
+
+	cache ??= new Map;
+	camera = cache.get(cacheCamera);
+	if (!camera) {
+		camera = new Camera({
+			width,
+			height,
+			imageType: imagetype,
+			format: "buffer/disposable",
+		});
+		cache.set(cacheCamera, camera)
+		camera.start();
+		};
+	}
 
     onMessage(msg, done) {
       try {


### PR DESCRIPTION
Hi, the mcu_camera node is a useful node for Node-RED MCU!

I was using this node to take pictures, but when I placed more than one node, an error occurred.
![image](https://github.com/user-attachments/assets/f08449dd-102b-4260-aca0-d42412ea8ca1)

I faced the same problem when I was developing the mcu_serial node.
I needed to create an instance of the Serial class for each port, not for each node.
https://github.com/404background/node-red-contrib-mcu-serial/issues/1


In order to properly handle instances of the Camera class, I added a cache variable in this PR.
Now I can take pictures even when multiple nodes are placed as shown below.
![image](https://github.com/user-attachments/assets/cc6c6974-604e-4f65-b5b5-78f70a1e8054)

If the nodes execute at the same time, the same result is output.
![image (5)](https://github.com/user-attachments/assets/281c3b38-d7a0-4972-a62f-b674162e44d1)

However, **the width and height of the nodes must all be the same** for this fix.
Note that I have tested with XIAO ESP32S3 Sense on Windows 11 environment.

Here is the flow.

```
[{"id":"8ec7eb62d213c9b3","type":"inject","z":"d6fad9e77ecc8414","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":true,"onceDelay":"1","topic":"","payload":"test","payloadType":"str","x":2670,"y":500,"wires":[["76c4778e163007ac"]]},{"id":"76c4778e163007ac","type":"debug","z":"d6fad9e77ecc8414","name":"debug 1","active":true,"tosidebar":true,"console":true,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":2850,"y":500,"wires":[]},{"id":"d868b8fba472e4e5","type":"inject","z":"d6fad9e77ecc8414","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":2700,"y":580,"wires":[["ea097ca9dae1ac1a","a6c856ae42eb57ca"]]},{"id":"647e1614640c8fc5","type":"debug","z":"d6fad9e77ecc8414","name":"debug 2","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","statusVal":"","statusType":"auto","x":3060,"y":580,"wires":[]},{"id":"ea097ca9dae1ac1a","type":"mcu_camera","z":"d6fad9e77ecc8414","name":"","imagetype":"jpeg","width":"176","height":"144","moddable_manifest":{"include":[{"git":"https://github.com/kitazaki/node-red-contrib-mcu-camera.git"}]},"x":2890,"y":580,"wires":[["647e1614640c8fc5"]]},{"id":"a7e9679d7dcac411","type":"http in","z":"d6fad9e77ecc8414","name":"","url":"/image","method":"get","upload":false,"swaggerDoc":"","x":2710,"y":680,"wires":[["86682bcc053e3d8b"]]},{"id":"8c44c5b27ccb4258","type":"http response","z":"d6fad9e77ecc8414","name":"","statusCode":"","headers":{},"x":3050,"y":680,"wires":[]},{"id":"86682bcc053e3d8b","type":"mcu_camera","z":"d6fad9e77ecc8414","name":"","imagetype":"jpeg","width":"176","height":"144","moddable_manifest":{"include":[{"git":"https://github.com/kitazaki/node-red-contrib-mcu-camera.git"}]},"x":2890,"y":680,"wires":[["8c44c5b27ccb4258"]]},{"id":"17576db96e60c4fc","type":"debug","z":"d6fad9e77ecc8414","name":"debug 6","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","statusVal":"","statusType":"auto","x":3060,"y":620,"wires":[]},{"id":"a6c856ae42eb57ca","type":"mcu_camera","z":"d6fad9e77ecc8414","name":"","imagetype":"jpeg","width":"176","height":"144","moddable_manifest":{"include":[{"git":"https://github.com/kitazaki/node-red-contrib-mcu-camera.git"}]},"x":2890,"y":620,"wires":[["17576db96e60c4fc"]]}]
```